### PR TITLE
Refactor admin dashboard data fetching and dialogs

### DIFF
--- a/components/admin-dashboard.tsx
+++ b/components/admin-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import useSWR from "swr"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -12,63 +12,95 @@ import { UsageAnalytics } from "@/components/usage-analytics"
 import { OrganizationManagement } from "@/components/organization-management"
 import type { Tenant, TestUser, App, UsageLog } from "@/lib/types"
 import Link from "next/link"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog"
+import { Skeleton } from "@/components/ui/skeleton"
 
 export function AdminDashboard() {
-  const [tenants, setTenants] = useState<Tenant[]>([])
-  const [users, setUsers] = useState<TestUser[]>([])
-  const [apps, setApps] = useState<App[]>([])
-  const [usageLogs, setUsageLogs] = useState<UsageLog[]>([])
-  const [loading, setLoading] = useState(true)
+  const fetcher = (url: string) => fetch(url).then((res) => res.json())
 
-  useEffect(() => {
-    fetchData()
-  }, [])
+  const {
+    data: tenants = [],
+    isLoading: tenantsLoading,
+    mutate: mutateTenants,
+  } = useSWR<Tenant[]>("/api/admin/organizations", fetcher)
+  const {
+    data: users = [],
+    isLoading: usersLoading,
+    mutate: mutateUsers,
+  } = useSWR<TestUser[]>("/api/admin/users", fetcher)
+  const { data: apps = [], isLoading: appsLoading, mutate: mutateApps } = useSWR<App[]>(
+    "/api/admin/apps",
+    fetcher
+  )
+  const {
+    data: usageLogs = [],
+    isLoading: logsLoading,
+    mutate: mutateLogs,
+  } = useSWR<UsageLog[]>("/api/admin/usage-logs", fetcher)
 
-  const fetchData = async () => {
-    try {
-      const [tenantsRes, usersRes, appsRes, logsRes] = await Promise.all([
-        fetch("/api/admin/organizations"),
-        fetch("/api/admin/users"),
-        fetch("/api/admin/apps"),
-        fetch("/api/admin/usage-logs"),
-      ])
+  const loading = tenantsLoading || usersLoading || appsLoading || logsLoading
 
-      const [tenantsData, usersData, appsData, logsData] = await Promise.all([
-        tenantsRes.json(),
-        usersRes.json(),
-        appsRes.json(),
-        logsRes.json(),
-      ])
-
-      setTenants(tenantsData)
-      setUsers(usersData)
-      setApps(appsData)
-      setUsageLogs(logsData)
-    } catch (error) {
-      console.error("Failed to fetch admin data:", error)
-    } finally {
-      setLoading(false)
-    }
+  const refreshData = () => {
+    mutateTenants()
+    mutateUsers()
+    mutateApps()
+    mutateLogs()
   }
 
   const handleDeleteUser = async (userId: string) => {
-    if (!confirm("Are you sure you want to delete this user?")) return
-
     try {
       const response = await fetch(`/api/admin/users/${userId}`, {
         method: "DELETE",
       })
-
       if (!response.ok) throw new Error("Failed to delete user")
-
-      fetchData() // Refresh data
+      mutateUsers()
     } catch (error) {
       console.error("Failed to delete user:", error)
     }
   }
 
   if (loading) {
-    return <div className="text-center py-12">Loading admin dashboard...</div>
+    return (
+      <div className="space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          {[1, 2, 3, 4].map((i) => (
+            <Card key={i}>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <Skeleton className="h-4 w-24" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-8 w-16" />
+                <Skeleton className="h-4 w-24 mt-2" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              <Skeleton className="h-6 w-32" />
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-12 w-full" />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
   }
 
   const totalMembers = tenants.reduce((sum, tenant) => sum + (tenant.member_count || 0), 0)
@@ -140,12 +172,15 @@ export function AdminDashboard() {
                 <CardTitle>Users</CardTitle>
                 <CardDescription>Manage user accounts</CardDescription>
               </div>
-              <UserManagementDialog onUserSaved={fetchData} />
+              <UserManagementDialog onUserSaved={refreshData} />
             </CardHeader>
             <CardContent>
               <div className="space-y-4">
                 {users.map((user) => (
-                  <div key={user.id} className="flex items-center justify-between p-4 border rounded-lg">
+                  <div
+                    key={user.id}
+                    className="flex items-center justify-between p-4 border rounded-lg"
+                  >
                     <div>
                       <h3 className="font-medium">{user.name}</h3>
                       <p className="text-sm text-gray-500">{user.email}</p>
@@ -156,16 +191,35 @@ export function AdminDashboard() {
                       )}
                     </div>
                     <div className="flex items-center gap-2">
-                      <Badge variant={user.role === "super_admin" ? "default" : "secondary"}>{user.role}</Badge>
-                      <UserManagementDialog user={user} onUserSaved={fetchData} />
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleDeleteUser(user.id)}
-                        className="text-red-600 hover:text-red-700"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
+                      <Badge variant={user.role === "super_admin" ? "default" : "secondary"}>
+                        {user.role}
+                      </Badge>
+                      <UserManagementDialog user={user} onUserSaved={refreshData} />
+                      <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="text-red-600 hover:text-red-700"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>Delete user?</AlertDialogTitle>
+                            <AlertDialogDescription>
+                              Are you sure you want to delete this user?
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>Cancel</AlertDialogCancel>
+                            <AlertDialogAction onClick={() => handleDeleteUser(user.id)}>
+                              Delete
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
                     </div>
                   </div>
                 ))}
@@ -229,7 +283,9 @@ export function AdminDashboard() {
                   <div key={log.id} className="flex items-center justify-between p-4 border rounded-lg">
                     <div>
                       <h3 className="font-medium">{log.action}</h3>
-                      <p className="text-sm text-gray-500">{new Date(log.created_at).toLocaleString()}</p>
+                      <p className="text-sm text-gray-500">
+                        {new Date(log.created_at).toLocaleString()}
+                      </p>
                     </div>
                     <Badge variant="outline">{log.metadata?.app_name || "Unknown App"}</Badge>
                   </div>
@@ -243,13 +299,15 @@ export function AdminDashboard() {
           <Card>
             <CardHeader>
               <CardTitle>System Testing</CardTitle>
-              <CardDescription>Test API keys, database connections, and system functionality</CardDescription>
+              <CardDescription>
+                Test API keys, database connections, and system functionality
+              </CardDescription>
             </CardHeader>
             <CardContent>
               <div className="text-center py-8">
                 <p className="text-gray-600 mb-4">
-                  Access comprehensive system testing tools including API key validation, database connectivity tests,
-                  and custom endpoint testing.
+                  Access comprehensive system testing tools including API key validation, database
+                  connectivity tests, and custom endpoint testing.
                 </p>
                 <Link href="/admin/test">
                   <Button className="nordic-button-primary">Open System Test Page</Button>
@@ -262,3 +320,4 @@ export function AdminDashboard() {
     </div>
   )
 }
+

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,8 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+export function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("animate-pulse rounded-md bg-muted", className)} {...props} />
+}
+

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-hook-form": "^7.60.0",
     "react-resizable-panels": "^2.1.7",
     "recharts": "latest",
+    "swr": "^2.2.0",
     "sonner": "^1.7.4",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Summary
- replace manual fetch calls with SWR for cached tenant, user, app and log data
- show skeleton placeholders during dashboard load
- use AlertDialog for user deletion confirmation
- add reusable Skeleton component and SWR dependency

## Testing
- `pnpm lint` *(fails: Command failed with exit code 1 - ESLint config prompt)*
- `pnpm add swr@^2.2.0` *(fails: GET https://registry.npmjs.org/swr: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_689dbd7fc8108332a762cae90afecd13